### PR TITLE
Update code scanning config to use standard CodeQL Go pack

### DIFF
--- a/.github/codeql.yml
+++ b/.github/codeql.yml
@@ -2,4 +2,5 @@ name: "My CodeQL config"
 
 queries:
   - uses: security-and-quality
-  - uses: github/codeql-go/ql/src/experimental/CWE-327@main
+packs:
+  - codeql/go-queries:experimental/CWE-327

--- a/.github/codeql.yml
+++ b/.github/codeql.yml
@@ -3,4 +3,4 @@ name: "My CodeQL config"
 queries:
   - uses: security-and-quality
 packs:
-  - codeql/go-queries:experimental/CWE-327
+  - 'codeql/go-queries:experimental/CWE-327'


### PR DESCRIPTION
The `codeql-go` repository is deprecated. See https://github.com/github/codeql-go/issues/741 for details.
Refer instead to the same query folder, but within the `codeql/go-queries` query pack that is bundled by default with CodeQL on Actions.